### PR TITLE
fix: use _linkedBinding when electronBinding not available

### DIFF
--- a/src/common/get-electron-binding.ts
+++ b/src/common/get-electron-binding.ts
@@ -1,0 +1,3 @@
+export const getElectronBinding: typeof process.electronBinding = process.electronBinding
+  ? (name: string) => process.electronBinding(name as any)
+  : (name: string) => (process as any)._linkedBinding('electron_common_' + name)

--- a/src/main/objects-registry.ts
+++ b/src/main/objects-registry.ts
@@ -1,6 +1,7 @@
 import { WebContents } from 'electron'
+import { getElectronBinding } from '../common/get-electron-binding'
 
-const v8Util = process.electronBinding('v8_util')
+const v8Util = getElectronBinding('v8_util')
 
 const getOwnerKey = (webContents: WebContents, contextId: string) => {
   return `${webContents.id}-${contextId}`

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -4,9 +4,10 @@ import { isPromise, isSerializableObject, deserialize, serialize } from '../comm
 import type { MetaTypeFromRenderer, ObjectMember, MetaType, ObjProtoDescriptor } from '../common/types'
 import { ipcMain, WebContents, IpcMainEvent, app } from 'electron'
 import { IPC_MESSAGES } from '../common/ipc-messages';
+import { getElectronBinding } from '../common/get-electron-binding'
 
-const v8Util = process.electronBinding('v8_util')
-const { NativeImage } = process.electronBinding('native_image')
+const v8Util = getElectronBinding('v8_util')
+const { NativeImage } = getElectronBinding('native_image')
 
 // The internal properties of Function.
 const FUNCTION_PROPERTIES = [

--- a/src/renderer/callbacks-registry.ts
+++ b/src/renderer/callbacks-registry.ts
@@ -1,4 +1,5 @@
-const v8Util = process.electronBinding('v8_util')
+import { getElectronBinding } from '../common/get-electron-binding'
+const v8Util = getElectronBinding('v8_util')
 
 export class CallbacksRegistry {
   private nextId: number = 0

--- a/src/renderer/remote.ts
+++ b/src/renderer/remote.ts
@@ -3,6 +3,7 @@ import { isPromise, isSerializableObject, serialize, deserialize } from '../comm
 import { MetaTypeFromRenderer, ObjectMember, ObjProtoDescriptor, MetaType } from '../common/types'
 import { BrowserWindow, WebContents, ipcRenderer } from 'electron'
 import { browserModules } from '../common/module-names'
+import { getElectronBinding } from '../common/get-electron-binding'
 import { IPC_MESSAGES } from '../common/ipc-messages';
 
 const v8Util = process.electronBinding('v8_util')


### PR DESCRIPTION
Fixes #15.

This was broken with https://github.com/electron/electron/pull/24191 when
`process.electronBinding` was removed.
