### PR TITLE
refactor: module list array, import nativeImage, type safety improvements

### DIFF
--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -1,51 +1,52 @@
 import { getElectronBinding } from './get-electron-binding'
 
-export const commonModules = [
-  { name: 'clipboard' },
-  { name: 'nativeImage' },
-  { name: 'shell' },
+export const commonModuleNames = [
+  'clipboard',
+  'nativeImage',
+  'shell',
 ];
 
-export const browserModules = [
-  { name: 'app' },
-  { name: 'autoUpdater' },
-  { name: 'BaseWindow' },
-  { name: 'BrowserView' },
-  { name: 'BrowserWindow' },
-  { name: 'contentTracing' },
-  { name: 'crashReporter' },
-  { name: 'desktopCapturer' },
-  { name: 'dialog' },
-  { name: 'globalShortcut' },
-  { name: 'ipcMain' },
-  { name: 'inAppPurchase' },
-  { name: 'Menu' },
-  { name: 'MenuItem' },
-  { name: 'nativeTheme' },
-  { name: 'net' },
-  { name: 'netLog' },
-  { name: 'MessageChannelMain' },
-  { name: 'Notification' },
-  { name: 'powerMonitor' },
-  { name: 'powerSaveBlocker' },
-  { name: 'protocol' },
-  { name: 'screen' },
-  { name: 'session' },
-  { name: 'ShareMenu' },
-  { name: 'systemPreferences' },
-  { name: 'TopLevelWindow' },
-  { name: 'TouchBar' },
-  { name: 'Tray' },
-  { name: 'View' },
-  { name: 'webContents' },
-  { name: 'WebContentsView' },
-  { name: 'webFrameMain' },
-].concat(commonModules);
+export const browserModuleNames = [
+  'app',
+  'autoUpdater',
+  'BaseWindow',
+  'BrowserView',
+  'BrowserWindow',
+  'contentTracing',
+  'crashReporter',
+  'dialog',
+  'globalShortcut',
+  'ipcMain',
+  'inAppPurchase',
+  'Menu',
+  'MenuItem',
+  'nativeTheme',
+  'net',
+  'netLog',
+  'MessageChannelMain',
+  'Notification',
+  'powerMonitor',
+  'powerSaveBlocker',
+  'protocol',
+  'screen',
+  'session',
+  'ShareMenu',
+  'systemPreferences',
+  'TopLevelWindow',
+  'TouchBar',
+  'Tray',
+  'View',
+  'webContents',
+  'WebContentsView',
+  'webFrameMain',
+].concat(commonModuleNames);
 
 const features = getElectronBinding('features');
 
+if (features.isDesktopCapturerEnabled()) {
+  browserModuleNames.push('desktopCapturer');
+}
+
 if (features.isViewApiEnabled()) {
-  browserModules.push(
-    { name: 'ImageView' }
-  );
+  browserModuleNames.push('ImageView');
 }

--- a/src/common/type-utils.ts
+++ b/src/common/type-utils.ts
@@ -1,5 +1,4 @@
-import { getElectronBinding } from './get-electron-binding'
-const { nativeImage } = getElectronBinding('native_image');
+import { nativeImage } from 'electron';
 
 export function isPromise (val: any) {
   return (
@@ -35,7 +34,7 @@ const objectMap = function (source: Object, mapper: (value: any) => any) {
   return Object.fromEntries(targetEntries);
 };
 
-function serializeNativeImage (image: any) {
+function serializeNativeImage (image: Electron.NativeImage) {
   const representations = [];
   const scaleFactors = image.getScaleFactors();
 

--- a/src/internal-ambient.d.ts
+++ b/src/internal-ambient.d.ts
@@ -1,8 +1,13 @@
+declare namespace Electron {
+  interface WebContents {
+    getLastWebPreferences(): WebPreferences;
+    getOwnerBrowserWindow(): BrowserWindow;
+  }
+}
+
 declare namespace NodeJS {
   interface V8UtilBinding {
-    getHiddenValue<T>(obj: any, key: string): T;
-    setHiddenValue<T>(obj: any, key: string, value: T): void;
-    deleteHiddenValue(obj: any, key: string): void;
+    getHiddenValue<T>(obj: Object, key: string): T;
   }
 
   interface EventBinding {
@@ -10,18 +15,13 @@ declare namespace NodeJS {
   }
 
   interface FeaturesBinding {
+    isDesktopCapturerEnabled(): boolean;
     isViewApiEnabled(): boolean;
-  }
-
-  interface NativeImageBinding {
-    nativeImage: any;
-    NativeImage: any;
   }
 
   interface Process {
     electronBinding(name: 'event'): EventBinding;
     electronBinding(name: 'v8_util'): V8UtilBinding;
-    electronBinding(name: 'native_image'): NativeImageBinding;
     electronBinding(name: 'features'): FeaturesBinding;
     electronBinding(name: 'command_line'): Electron.CommandLine;
   }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -199,7 +199,7 @@ const removeRemoteListenersAndLogWarning = (sender: any, callIntoRenderer: (...a
     if (remoteEvents.length > 0) {
       message += `\nRemote event names: ${remoteEvents.join(', ')}`
       remoteEvents.forEach((eventName) => {
-        sender.removeListener(eventName as any, callIntoRenderer)
+        sender.removeListener(eventName, callIntoRenderer)
       })
     }
   }
@@ -288,7 +288,7 @@ const unwrapArgs = function (sender: WebContents, frameId: number, contextId: st
 }
 
 const isRemoteModuleEnabledImpl = function (contents: WebContents) {
-  const webPreferences = (contents as any).getLastWebPreferences() || {}
+  const webPreferences = contents.getLastWebPreferences() || {}
   return webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : false
 }
 
@@ -411,7 +411,7 @@ export function initialize() {
       if (customEvent.defaultPrevented) {
         throw new Error('Blocked remote.getCurrentWindow()')
       } else {
-        customEvent.returnValue = (event.sender as any).getOwnerBrowserWindow()
+        customEvent.returnValue = event.sender.getOwnerBrowserWindow()
       }
     }
 

--- a/src/renderer/remote.ts
+++ b/src/renderer/remote.ts
@@ -2,7 +2,7 @@ import { CallbacksRegistry } from './callbacks-registry'
 import { isPromise, isSerializableObject, serialize, deserialize } from '../common/type-utils'
 import { MetaTypeFromRenderer, ObjectMember, ObjProtoDescriptor, MetaType } from '../common/types'
 import { BrowserWindow, WebContents, ipcRenderer } from 'electron'
-import { browserModules } from '../common/module-names'
+import { browserModuleNames } from '../common/module-names'
 import { getElectronBinding } from '../common/get-electron-binding'
 import { IPC_MESSAGES } from '../common/ipc-messages';
 
@@ -389,6 +389,5 @@ const addBuiltinProperty = (name: string) => {
   })
 }
 
-browserModules
-  .map((m) => m.name)
+browserModuleNames
   .forEach(addBuiltinProperty)


### PR DESCRIPTION
The following changes are mirroring code in Electron core
- [module names as array](https://github.com/electron/electron/blob/4f2490f8b80683dd115f851d84b123e854e32e43/lib/browser/api/module-names.ts#L7-L40)
- [desktopCapturer only when enabled](https://github.com/electron/electron/blob/4f2490f8b80683dd115f851d84b123e854e32e43/lib/browser/api/module-names.ts#L42-L44)
- chore: remove bunch of usages of any [#27512](https://github.com/electron/electron/pull/27512)