### PR TITLE
fix: Add main type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+interface NodeRequireFunction {
+  (moduleName: 'electron'): typeof Electron;
+}
+
+interface NodeRequire extends NodeRequireFunction {
+  resolve: RequireResolve;
+  cache: NodeRequireCache;
+  /**
+   * @deprecated
+   */
+  extensions: NodeExtensions;
+  main: NodeModule | undefined;
+}
+
+export declare var require: NodeRequire;
+
+// Taken from `RemoteMainInterface`
+export {app, autoUpdater, BrowserView, BrowserWindow, ClientRequest, clipboard, CommandLine, contentTracing, Cookies, crashReporter, Debugger, desktopCapturer, dialog, Dock, DownloadItem, globalShortcut, inAppPurchase, IncomingMessage, ipcMain, Menu, MenuItem, MessageChannelMain, MessagePortMain, nativeImage, nativeTheme, net, netLog, Notification, powerMonitor, powerSaveBlocker, protocol, screen, ServiceWorkers, session, shell, systemPreferences, TouchBar, TouchBarButton, TouchBarColorPicker, TouchBarGroup, TouchBarLabel, TouchBarOtherItemsProxy, TouchBarPopover, TouchBarScrubber, TouchBarSegmentedControl, TouchBarSlider, TouchBarSpacer, Tray, webContents, WebRequest} from 'electron';
+export * from './dist/src/main'
+export * from './dist/src/renderer';

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "package.json",
     "main/index.js",
     "renderer/index.js",
-    "dist/src"
-  ]
+    "dist/src",
+    "index.d.ts"
+  ],
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
I noticed that the file defined in `main` in the `package.json` file doesn't have type declarations since it is written in JavaScript.
This fix might help with https://github.com/electron/remote/issues/35.