### PR TITLE
refactor: don't use command_line binding

### DIFF
--- a/src/internal-ambient.d.ts
+++ b/src/internal-ambient.d.ts
@@ -23,6 +23,5 @@ declare namespace NodeJS {
     electronBinding(name: 'event'): EventBinding;
     electronBinding(name: 'v8_util'): V8UtilBinding;
     electronBinding(name: 'features'): FeaturesBinding;
-    electronBinding(name: 'command_line'): Electron.CommandLine;
   }
 }

--- a/src/renderer/remote.ts
+++ b/src/renderer/remote.ts
@@ -7,7 +7,6 @@ import { getElectronBinding } from '../common/get-electron-binding'
 import { IPC_MESSAGES } from '../common/ipc-messages';
 
 const v8Util = getElectronBinding('v8_util')
-const { hasSwitch } = getElectronBinding('command_line')
 
 const callbacksRegistry = new CallbacksRegistry()
 const remoteObjectCache = new Map()
@@ -316,7 +315,7 @@ function handleMessage (channel: string, handler: Function) {
   })
 }
 
-const enableStacks = hasSwitch('enable-api-filtering-logging')
+const enableStacks = process.argv.includes('--enable-api-filtering-logging')
 
 function getCurrentStack (): string | undefined {
   const target = { stack: undefined as string | undefined }


### PR DESCRIPTION
`process._linkedBinding()` / `process.electronBinding()` are not available in sandboxed renderers