### PR TITLE
feat: add support for running in sandboxed renderers

### DIFF
--- a/src/common/get-electron-binding.ts
+++ b/src/common/get-electron-binding.ts
@@ -1,3 +1,9 @@
-export const getElectronBinding: typeof process.electronBinding = process.electronBinding
-  ? (name: string) => process.electronBinding(name as any)
-  : (name: string) => (process as any)._linkedBinding('electron_common_' + name)
+export const getElectronBinding: typeof process.electronBinding = (name: string) => {
+  if ((process as any)._linkedBinding) {
+    return (process as any)._linkedBinding('electron_common_' + name)
+  } else if (process.electronBinding) {
+    return process.electronBinding(name as any)
+  } else {
+    return null
+  }
+}

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -43,10 +43,10 @@ export const browserModuleNames = [
 
 const features = getElectronBinding('features');
 
-if (features.isDesktopCapturerEnabled()) {
+if (!features || features.isDesktopCapturerEnabled()) {
   browserModuleNames.push('desktopCapturer');
 }
 
-if (features.isViewApiEnabled()) {
+if (!features || features.isViewApiEnabled()) {
   browserModuleNames.push('ImageView');
 }

--- a/src/internal-ambient.d.ts
+++ b/src/internal-ambient.d.ts
@@ -23,5 +23,6 @@ declare namespace NodeJS {
     electronBinding(name: 'event'): EventBinding;
     electronBinding(name: 'v8_util'): V8UtilBinding;
     electronBinding(name: 'features'): FeaturesBinding;
+    readonly contextId: string;
   }
 }

--- a/src/renderer/remote.ts
+++ b/src/renderer/remote.ts
@@ -38,7 +38,7 @@ function getContextId() {
   if (v8Util) {
     return v8Util.getHiddenValue<string>(global, 'contextId')
   } else {
-    throw new Error('Electron v13.0.0-beta.6 required to support sandboxed renderers')
+    throw new Error('Electron >=v13.0.0-beta.6 required to support sandboxed renderers')
   }
 }
 

--- a/src/renderer/remote.ts
+++ b/src/renderer/remote.ts
@@ -6,8 +6,6 @@ import { browserModuleNames } from '../common/module-names'
 import { getElectronBinding } from '../common/get-electron-binding'
 import { IPC_MESSAGES } from '../common/ipc-messages';
 
-const v8Util = getElectronBinding('v8_util')
-
 const callbacksRegistry = new CallbacksRegistry()
 const remoteObjectCache = new Map()
 const finalizationRegistry = new FinalizationRegistry((id: number) => {
@@ -35,8 +33,17 @@ function setCachedRemoteObject (id: number, value: any) {
   return value
 }
 
+function getContextId() {
+  const v8Util = getElectronBinding('v8_util')
+  if (v8Util) {
+    return v8Util.getHiddenValue<string>(global, 'contextId')
+  } else {
+    throw new Error('Electron v13.0.0-beta.6 required to support sandboxed renderers')
+  }
+}
+
 // An unique ID that can represent current context.
-const contextId = v8Util.getHiddenValue<string>(global, 'contextId')
+const contextId = process.contextId || getContextId()
 
 // Notify the main process when current context is going to be released.
 // Note that when the renderer process is destroyed, the message may not be


### PR DESCRIPTION
- Use `process.contextId` added by https://github.com/electron/electron/pull/28007 to avoid using `v8_util` binding
- Enable all Electron modules when `features` binding cannot be used

Closes #42.