### PR TITLE
fix: Exclude index.d.ts from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true
-  }
+  },
+  "exclude": ["index.d.ts"]
 }


### PR DESCRIPTION
Currently the tests are failing on main because `tsc` can't be properly executed. Since we don't need to build the `index.d.ts` file, we can just exclude it and it will be published as it is.

cc @nornagon 