### PR TITLE
fix!: change enableRemoteModule to .enable() for electron@14

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ process before it can be used from the renderer:
 
 ```javascript
 // in the main process:
-require('@electron/remote/main').initialize()
+require("@electron/remote/main").initialize();
 ```
 
 Third, `require('electron').remote` in the renderer process must be
@@ -40,10 +40,10 @@ replaced with `require('@electron/remote')`.
 // in the renderer process:
 
 // Before
-const { BrowserWindow } = require('electron').remote
+const { BrowserWindow } = require("electron").remote;
 
 // After
-const { BrowserWindow } = require('@electron/remote')
+const { BrowserWindow } = require("@electron/remote");
 ```
 
 **Note:** Since this is requiring a module through npm rather than a built-in
@@ -52,11 +52,10 @@ configure your bundler appropriately to package the code of `@electron/remote`
 in the preload script. Of course, [using `@electron/remote` makes the sandbox
 much less effective][remote-considered-harmful].
 
-**Note:** `@electron/remote` respects the `enableRemoteModule` WebPreferences
+**Note:** for `electron` versions below `14.0.0`, `@electron/remote` respects the `enableRemoteModule` WebPreferences
 value. You must pass `{ webPreferences: { enableRemoteModule: true } }` to
 the constructor of `BrowserWindow`s that should be granted permission to use
 `@electron/remote`.
-
 
 # API Reference
 
@@ -72,9 +71,9 @@ similar to Java's [RMI][rmi]. An example of creating a browser window from a
 renderer process:
 
 ```javascript
-const { BrowserWindow } = require('@electron/remote')
-let win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('https://github.com')
+const { BrowserWindow } = require("@electron/remote");
+let win = new BrowserWindow({ width: 800, height: 600 });
+win.loadURL("https://github.com");
 ```
 
 In order for this to work, you first need to initialize the main-process side
@@ -82,10 +81,11 @@ of the remote module:
 
 ```javascript
 // in the main process:
-require('@electron/remote/main').initialize()
+require("@electron/remote/main").initialize();
 ```
 
-**Note:** The remote module can be disabled for security reasons in the following contexts:
+**Note:** In `electron < 14.0.0` the remote module can be disabled for security reasons in the following contexts:
+
 - [`BrowserWindow`](browser-window.md) - by setting the `enableRemoteModule` option to `false`.
 - [`<webview>`](webview-tag.md) - by setting the `enableremotemodule` attribute to `false`.
 
@@ -140,21 +140,21 @@ For instance you can't use a function from the renderer process in an
 ```javascript
 // main process mapNumbers.js
 exports.withRendererCallback = (mapper) => {
-  return [1, 2, 3].map(mapper)
-}
+  return [1, 2, 3].map(mapper);
+};
 
 exports.withLocalCallback = () => {
-  return [1, 2, 3].map(x => x + 1)
-}
+  return [1, 2, 3].map((x) => x + 1);
+};
 ```
 
 ```javascript
 // renderer process
-const mapNumbers = require('@electron/remote').require('./mapNumbers')
-const withRendererCb = mapNumbers.withRendererCallback(x => x + 1)
-const withLocalCb = mapNumbers.withLocalCallback()
+const mapNumbers = require("@electron/remote").require("./mapNumbers");
+const withRendererCb = mapNumbers.withRendererCallback((x) => x + 1);
+const withLocalCb = mapNumbers.withLocalCallback();
 
-console.log(withRendererCb, withLocalCb)
+console.log(withRendererCb, withLocalCb);
 // [undefined, undefined, undefined], [2, 3, 4]
 ```
 
@@ -169,9 +169,11 @@ For example, the following code seems innocent at first glance. It installs a
 callback for the `close` event on a remote object:
 
 ```javascript
-require('@electron/remote').getCurrentWindow().on('close', () => {
-  // window was closed...
-})
+require("@electron/remote")
+  .getCurrentWindow()
+  .on("close", () => {
+    // window was closed...
+  });
 ```
 
 But remember the callback is referenced by the main process until you
@@ -193,8 +195,8 @@ The built-in modules in the main process are added as getters in the `remote`
 module, so you can use them directly like the `electron` module.
 
 ```javascript
-const app = require('@electron/remote').app
-console.log(app)
+const app = require("@electron/remote").app;
+console.log(app);
 ```
 
 ## Methods
@@ -203,7 +205,7 @@ The `remote` module has the following methods:
 
 ### `remote.require(module)`
 
-* `module` String
+- `module` String
 
 Returns `any` - The object returned by `require(module)` in the main process.
 Modules specified by their relative path will resolve relative to the entrypoint
@@ -223,25 +225,27 @@ project/
 
 ```js
 // main process: main/index.js
-const { app } = require('@electron/remote')
-app.whenReady().then(() => { /* ... */ })
+const { app } = require("@electron/remote");
+app.whenReady().then(() => {
+  /* ... */
+});
 ```
 
 ```js
 // some relative module: main/foo.js
-module.exports = 'bar'
+module.exports = "bar";
 ```
 
 ```js
 // renderer process: renderer/index.js
-const foo = require('@electron/remote').require('./foo') // bar
+const foo = require("@electron/remote").require("./foo"); // bar
 ```
 
 ### `remote.getCurrentWindow()`
 
 Returns `BrowserWindow` - The window to which this web page belongs.
 
-**Note:** Do not use `removeAllListeners` on `BrowserWindow`.  Use of this can
+**Note:** Do not use `removeAllListeners` on `BrowserWindow`. Use of this can
 remove all [`blur`](https://developer.mozilla.org/en-US/docs/Web/Events/blur)
 listeners, disable click events on touch bar buttons, and other unintended
 consequences.
@@ -252,7 +256,7 @@ Returns `WebContents` - The web contents of this web page.
 
 ### `remote.getGlobal(name)`
 
-* `name` String
+- `name` String
 
 Returns `any` - The global variable of `name` (e.g. `global[name]`) in the main
 process.
@@ -261,7 +265,7 @@ process.
 
 ### `remote.process` _Readonly_
 
-A `NodeJS.Process` object.  The `process` object in the main process. This is the same as
+A `NodeJS.Process` object. The `process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
 # Overriding exposed objects
@@ -286,8 +290,8 @@ the default.
 
 Returns:
 
-* `event` Event
-* `moduleName` String
+- `event` Event
+- `moduleName` String
 
 Emitted when `remote.require()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -297,8 +301,8 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
-* `globalName` String
+- `event` Event
+- `globalName` String
 
 Emitted when `remote.getGlobal()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the global from being returned.
@@ -308,8 +312,8 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
-* `moduleName` String
+- `event` Event
+- `moduleName` String
 
 Emitted when `remote.getBuiltin()` is called in the renderer process of
 `webContents`, including when a builtin module is accessed as a property (e.g.
@@ -321,7 +325,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+- `event` Event
 
 Emitted when `remote.getCurrentWindow()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the object from being returned.
@@ -331,7 +335,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+- `event` Event
 
 Emitted when `remote.getCurrentWebContents()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the object from being returned.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ configure your bundler appropriately to package the code of `@electron/remote`
 in the preload script. Of course, [using `@electron/remote` makes the sandbox
 much less effective][remote-considered-harmful].
 
-**Note:** in `electron < 14.0.0`, `@electron/remote` respects the `enableRemoteModule` WebPreferences
+**Note:** In `electron >= 14.0.0`, you must use the new `enable` API to enable the remote module for each desired `WebContents` separately: `require("@electron/remote/main").enable(webContents)`.
+
+In `electron < 14.0.0`, `@electron/remote` respects the `enableRemoteModule` WebPreferences
 value. You must pass `{ webPreferences: { enableRemoteModule: true } }` to
 the constructor of `BrowserWindow`s that should be granted permission to use
 `@electron/remote`.
-
-In `electron >= 14.0.0`, you must use the new `permit` API to enable the remote module for each desired `WebContents` separately: `require("@electron/remote/main").permit(webContents)`.
 
 # API Reference
 
@@ -86,11 +86,11 @@ of the remote module:
 require('@electron/remote/main').initialize()
 ```
 
-**Note:** In `electron < 14.0.0` the remote module can be disabled for security reasons in the following contexts:
+**Note:** In `electron >= 14.0.0` the remote module is disabled by default for any `WebContents` instance and is only enabled for specified `WebContents` after explicitly calling `require("@electron/remote/main").enable(webContents)`.
+
+In `electron < 14.0.0` the remote module can be disabled for security reasons in the following contexts:
 - [`BrowserWindow`](browser-window.md) - by setting the `enableRemoteModule` option to `false`.
 - [`<webview>`](webview-tag.md) - by setting the `enableremotemodule` attribute to `false`.
-
-In `electron >= 14.0.0` the remote module is disabled by default for any `WebContents` instance and is only enabled for specified `WebContents` after explicitly calling `require("@electron/remote/main").permit(webContents)`.
 
 ## Remote Objects
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ configure your bundler appropriately to package the code of `@electron/remote`
 in the preload script. Of course, [using `@electron/remote` makes the sandbox
 much less effective][remote-considered-harmful].
 
-**Note:** for `electron` versions below `14.0.0`, `@electron/remote` respects the `enableRemoteModule` WebPreferences
+**Note:** in `electron < 14.0.0`, `@electron/remote` respects the `enableRemoteModule` WebPreferences
 value. You must pass `{ webPreferences: { enableRemoteModule: true } }` to
 the constructor of `BrowserWindow`s that should be granted permission to use
 `@electron/remote`.
 
+In `electron >= 14.0.0`, you must use the new `permit` API to enable the remote module for each desired `WebContents` separately: `require(@electron/remote/main).permit(webContents)`.
 
 # API Reference
 
@@ -88,6 +89,8 @@ require('@electron/remote/main').initialize()
 **Note:** In `electron < 14.0.0` the remote module can be disabled for security reasons in the following contexts:
 - [`BrowserWindow`](browser-window.md) - by setting the `enableRemoteModule` option to `false`.
 - [`<webview>`](webview-tag.md) - by setting the `enableremotemodule` attribute to `false`.
+
+In `electron >= 14.0.0` the remote module is disabled by default for any `WebContents` instance and is only enabled for specified `WebContents` after explicitly calling `require(@electron/remote/main).permit(webContents)`.
 
 ## Remote Objects
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ process before it can be used from the renderer:
 
 ```javascript
 // in the main process:
-require("@electron/remote/main").initialize();
+require('@electron/remote/main').initialize()
 ```
 
 Third, `require('electron').remote` in the renderer process must be
@@ -40,10 +40,10 @@ replaced with `require('@electron/remote')`.
 // in the renderer process:
 
 // Before
-const { BrowserWindow } = require("electron").remote;
+const { BrowserWindow } = require('electron').remote
 
 // After
-const { BrowserWindow } = require("@electron/remote");
+const { BrowserWindow } = require('@electron/remote')
 ```
 
 **Note:** Since this is requiring a module through npm rather than a built-in
@@ -56,6 +56,7 @@ much less effective][remote-considered-harmful].
 value. You must pass `{ webPreferences: { enableRemoteModule: true } }` to
 the constructor of `BrowserWindow`s that should be granted permission to use
 `@electron/remote`.
+
 
 # API Reference
 
@@ -71,9 +72,9 @@ similar to Java's [RMI][rmi]. An example of creating a browser window from a
 renderer process:
 
 ```javascript
-const { BrowserWindow } = require("@electron/remote");
-let win = new BrowserWindow({ width: 800, height: 600 });
-win.loadURL("https://github.com");
+const { BrowserWindow } = require('@electron/remote')
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.loadURL('https://github.com')
 ```
 
 In order for this to work, you first need to initialize the main-process side
@@ -81,11 +82,10 @@ of the remote module:
 
 ```javascript
 // in the main process:
-require("@electron/remote/main").initialize();
+require('@electron/remote/main').initialize()
 ```
 
 **Note:** In `electron < 14.0.0` the remote module can be disabled for security reasons in the following contexts:
-
 - [`BrowserWindow`](browser-window.md) - by setting the `enableRemoteModule` option to `false`.
 - [`<webview>`](webview-tag.md) - by setting the `enableremotemodule` attribute to `false`.
 
@@ -140,21 +140,21 @@ For instance you can't use a function from the renderer process in an
 ```javascript
 // main process mapNumbers.js
 exports.withRendererCallback = (mapper) => {
-  return [1, 2, 3].map(mapper);
-};
+  return [1, 2, 3].map(mapper)
+}
 
 exports.withLocalCallback = () => {
-  return [1, 2, 3].map((x) => x + 1);
-};
+  return [1, 2, 3].map(x => x + 1)
+}
 ```
 
 ```javascript
 // renderer process
-const mapNumbers = require("@electron/remote").require("./mapNumbers");
-const withRendererCb = mapNumbers.withRendererCallback((x) => x + 1);
-const withLocalCb = mapNumbers.withLocalCallback();
+const mapNumbers = require('@electron/remote').require('./mapNumbers')
+const withRendererCb = mapNumbers.withRendererCallback(x => x + 1)
+const withLocalCb = mapNumbers.withLocalCallback()
 
-console.log(withRendererCb, withLocalCb);
+console.log(withRendererCb, withLocalCb)
 // [undefined, undefined, undefined], [2, 3, 4]
 ```
 
@@ -169,11 +169,9 @@ For example, the following code seems innocent at first glance. It installs a
 callback for the `close` event on a remote object:
 
 ```javascript
-require("@electron/remote")
-  .getCurrentWindow()
-  .on("close", () => {
-    // window was closed...
-  });
+require('@electron/remote').getCurrentWindow().on('close', () => {
+  // window was closed...
+})
 ```
 
 But remember the callback is referenced by the main process until you
@@ -195,8 +193,8 @@ The built-in modules in the main process are added as getters in the `remote`
 module, so you can use them directly like the `electron` module.
 
 ```javascript
-const app = require("@electron/remote").app;
-console.log(app);
+const app = require('@electron/remote').app
+console.log(app)
 ```
 
 ## Methods
@@ -205,7 +203,7 @@ The `remote` module has the following methods:
 
 ### `remote.require(module)`
 
-- `module` String
+* `module` String
 
 Returns `any` - The object returned by `require(module)` in the main process.
 Modules specified by their relative path will resolve relative to the entrypoint
@@ -216,8 +214,8 @@ e.g.
 ```sh
 project/
 ├── main
-│   ├── foo.js
-│   └── index.js
+│   ├── foo.js
+│   └── index.js
 ├── package.json
 └── renderer
     └── index.js
@@ -225,27 +223,25 @@ project/
 
 ```js
 // main process: main/index.js
-const { app } = require("@electron/remote");
-app.whenReady().then(() => {
-  /* ... */
-});
+const { app } = require('@electron/remote')
+app.whenReady().then(() => { /* ... */ })
 ```
 
 ```js
 // some relative module: main/foo.js
-module.exports = "bar";
+module.exports = 'bar'
 ```
 
 ```js
 // renderer process: renderer/index.js
-const foo = require("@electron/remote").require("./foo"); // bar
+const foo = require('@electron/remote').require('./foo') // bar
 ```
 
 ### `remote.getCurrentWindow()`
 
 Returns `BrowserWindow` - The window to which this web page belongs.
 
-**Note:** Do not use `removeAllListeners` on `BrowserWindow`. Use of this can
+**Note:** Do not use `removeAllListeners` on `BrowserWindow`.  Use of this can
 remove all [`blur`](https://developer.mozilla.org/en-US/docs/Web/Events/blur)
 listeners, disable click events on touch bar buttons, and other unintended
 consequences.
@@ -256,7 +252,7 @@ Returns `WebContents` - The web contents of this web page.
 
 ### `remote.getGlobal(name)`
 
-- `name` String
+* `name` String
 
 Returns `any` - The global variable of `name` (e.g. `global[name]`) in the main
 process.
@@ -265,7 +261,7 @@ process.
 
 ### `remote.process` _Readonly_
 
-A `NodeJS.Process` object. The `process` object in the main process. This is the same as
+A `NodeJS.Process` object.  The `process` object in the main process. This is the same as
 `remote.getGlobal('process')` but is cached.
 
 # Overriding exposed objects
@@ -290,8 +286,8 @@ the default.
 
 Returns:
 
-- `event` Event
-- `moduleName` String
+* `event` Event
+* `moduleName` String
 
 Emitted when `remote.require()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -301,8 +297,8 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-- `event` Event
-- `globalName` String
+* `event` Event
+* `globalName` String
 
 Emitted when `remote.getGlobal()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the global from being returned.
@@ -312,8 +308,8 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-- `event` Event
-- `moduleName` String
+* `event` Event
+* `moduleName` String
 
 Emitted when `remote.getBuiltin()` is called in the renderer process of
 `webContents`, including when a builtin module is accessed as a property (e.g.
@@ -325,7 +321,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-- `event` Event
+* `event` Event
 
 Emitted when `remote.getCurrentWindow()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the object from being returned.
@@ -335,7 +331,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-- `event` Event
+* `event` Event
 
 Emitted when `remote.getCurrentWebContents()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the object from being returned.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ value. You must pass `{ webPreferences: { enableRemoteModule: true } }` to
 the constructor of `BrowserWindow`s that should be granted permission to use
 `@electron/remote`.
 
-In `electron >= 14.0.0`, you must use the new `permit` API to enable the remote module for each desired `WebContents` separately: `require(@electron/remote/main).permit(webContents)`.
+In `electron >= 14.0.0`, you must use the new `permit` API to enable the remote module for each desired `WebContents` separately: `require("@electron/remote/main").permit(webContents)`.
 
 # API Reference
 
@@ -90,7 +90,7 @@ require('@electron/remote/main').initialize()
 - [`BrowserWindow`](browser-window.md) - by setting the `enableRemoteModule` option to `false`.
 - [`<webview>`](webview-tag.md) - by setting the `enableremotemodule` attribute to `false`.
 
-In `electron >= 14.0.0` the remote module is disabled by default for any `WebContents` instance and is only enabled for specified `WebContents` after explicitly calling `require(@electron/remote/main).permit(webContents)`.
+In `electron >= 14.0.0` the remote module is disabled by default for any `WebContents` instance and is only enabled for specified `WebContents` after explicitly calling `require("@electron/remote/main").permit(webContents)`.
 
 ## Remote Objects
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,1 +1,1 @@
-export { initialize } from './server'
+export { initialize, permit } from './server'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,1 +1,1 @@
-export { initialize, permit } from './server'
+export { initialize, enable } from "./server";

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -307,9 +307,9 @@ export const isRemoteModuleEnabled = function (contents: WebContents) {
   return isRemoteModuleEnabledCache.get(contents)
 }
 
-export function permit(contents: WebContents) {
+export function enable(contents: WebContents) {
   if (hasWebPrefsRemoteModuleAPI) {
-    throw new Error("The permit API is available only for electron >= 14.0.0")
+    throw new Error("The `enable` API is available only for electron >= 14.0.0")
   }
 
   isRemoteModuleEnabledCache.set(contents, true)
@@ -326,7 +326,7 @@ const handleRemoteCommand = function (channel: string, handler: (event: IpcMainE
           `@electron/remote is disabled for this WebContents. ${
             hasWebPrefsRemoteModuleAPI
               ? "Set {enableRemoteModule: true} in WebPreferences"
-              : "Call 'require(\"@electron/remote/main\").permit(webContents)'"
+              : "Call 'require(\"@electron/remote/main\").enable(webContents)'"
           } to enable it.`
         ))
       }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -308,9 +308,6 @@ export const isRemoteModuleEnabled = function (contents: WebContents) {
 }
 
 export function enable(contents: WebContents) {
-  if (hasWebPrefsRemoteModuleAPI) {
-    throw new Error("The `enable` API is available only for electron >= 14.0.0")
-  }
 
   isRemoteModuleEnabledCache.set(contents, true)
 }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -308,7 +308,6 @@ export const isRemoteModuleEnabled = function (contents: WebContents) {
 }
 
 export function enable(contents: WebContents) {
-
   isRemoteModuleEnabledCache.set(contents, true)
 }
 

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -303,9 +303,12 @@ export const isRemoteModuleEnabled = function (contents: WebContents) {
 }
 
 const handleRemoteCommand = function (channel: string, handler: (event: IpcMainEvent, contextId: string, ...args: any[]) => void) {
+  const electronVersion = Number(process.versions.electron?.split(".")?.[0]),
+    checkRemoteModuleEnabled = Number.isNaN(electronVersion) || electronVersion < 14;
+  
   ipcMain.on(channel, (event, contextId: string, ...args: any[]) => {
     let returnValue: MetaType | null | void
-    if (!isRemoteModuleEnabled(event.sender)) {
+    if (checkRemoteModuleEnabled && !isRemoteModuleEnabled(event.sender)) {
       event.returnValue = {
         type: 'exception',
         value: valueToMeta(event.sender, contextId, new Error('@electron/remote is disabled for this WebContents. Set {enableRemoteModule: true} in WebPreferences to enable it.'))

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -319,11 +319,7 @@ const handleRemoteCommand = function (channel: string, handler: (event: IpcMainE
       event.returnValue = {
         type: 'exception',
         value: valueToMeta(event.sender, contextId, new Error(
-          `@electron/remote is disabled for this WebContents. ${
-            hasWebPrefsRemoteModuleAPI
-              ? "Set {enableRemoteModule: true} in WebPreferences"
-              : "Call 'require(\"@electron/remote/main\").enable(webContents)'"
-          } to enable it.`
+          '@electron/remote is disabled for this WebContents. Call require("@electron/remote/main").enable(webContents) to enable it.'
         ))
       }
       return


### PR DESCRIPTION
BREAKING CHANGE: This removes the `enableRemoteModule` option in favor of a new `.enable()` method for enabling the remote module on a particular WebContents. See https://github.com/electron/remote/blob/main/docs/migration-2.md for migration instructions.

Fixes #71 