### PR TITLE
docs: add .initialize() to avoid users removing it

### DIFF
--- a/docs/migration-2.md
+++ b/docs/migration-2.md
@@ -13,6 +13,7 @@ that contents, you must call `enable()`:
 ```js
 // Main process
 const remoteMain = require("@electron/remote/main")
+remoteMain.initialize()
 
 const win = new BrowserWindow(/* ... */)
 remoteMain.enable(win.webContents)
@@ -34,6 +35,7 @@ const win = new BrowserWindow({
 
 // After (@electron/remote@2.x)
 const remoteMain = require("@electron/remote/main")
+remoteMain.initialize()
 const win = new BrowserWindow()
 remoteMain.enable(win.webContents)
 ```


### PR DESCRIPTION
Added `.initialize()` in migration-v2 guide. I am doing this PR because the guide on whether to keep that line of code or not was not very clear, also because that line is not even mentioned in migration-v2, making the developer think to remove it. (ref. #79 )