### PR TITLE
test: Test multiple electron versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,40 +23,40 @@ version: 2.1
 jobs:
   test-electron-13:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     <<: *steps-test
 
   test-electron-11:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     environment:
       ELECTRON_VERSION: 11.x
     <<: *steps-test
 
   test-electron-12:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     environment:
       ELECTRON_VERSION: 12.x
     <<: *steps-test
 
   test-electron-14:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     environment:
       ELECTRON_VERSION: 14.x
     <<: *steps-test
 
   test-electron-15:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     environment:
       ELECTRON_VERSION: 15.x
     <<: *steps-test
 
   release:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     steps:
       - checkout
       - *step-restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,40 +23,40 @@ version: 2.1
 jobs:
   test-electron-13:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     <<: *steps-test
 
   test-electron-11:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     environment:
       ELECTRON_VERSION: 11.x
     <<: *steps-test
 
   test-electron-12:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     environment:
       ELECTRON_VERSION: 12.x
     <<: *steps-test
 
   test-electron-14:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     environment:
       ELECTRON_VERSION: 14.x
     <<: *steps-test
 
   test-electron-15:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     environment:
       ELECTRON_VERSION: 15.x
     <<: *steps-test
 
   release:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     steps:
       - checkout
       - *step-restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,20 +40,6 @@ jobs:
       ELECTRON_VERSION: 12.x
     <<: *steps-test
 
-  test-electron-14:
-    docker:
-      - image: circleci/node:14-browsers
-    environment:
-      ELECTRON_VERSION: 14.x
-    <<: *steps-test
-
-  test-electron-15:
-    docker:
-      - image: circleci/node:14-browsers
-    environment:
-      ELECTRON_VERSION: 15.x
-    <<: *steps-test
-
   release:
     docker:
       - image: circleci/node:14-browsers
@@ -69,8 +55,6 @@ workflows:
       - test-electron-13
       - test-electron-11
       - test-electron-12
-      - test-electron-14
-      - test-electron-15
       - release:
           requires:
             - test-electron-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ steps-test: &steps-test
 
 version: 2.1
 jobs:
-  test:
+  test-electron-13:
     docker:
       - image: circleci/node:10-browsers
     <<: *steps-test
@@ -31,6 +31,27 @@ jobs:
       - image: circleci/node:10-browsers
     environment:
       ELECTRON_VERSION: 11.x
+    <<: *steps-test
+
+  test-electron-12:
+    docker:
+      - image: circleci/node:10-browsers
+    environment:
+      ELECTRON_VERSION: 12.x
+    <<: *steps-test
+
+  test-electron-14:
+    docker:
+      - image: circleci/node:10-browsers
+    environment:
+      ELECTRON_VERSION: 14.x
+    <<: *steps-test
+
+  test-electron-15:
+    docker:
+      - image: circleci/node:10-browsers
+    environment:
+      ELECTRON_VERSION: 15.x
     <<: *steps-test
 
   release:
@@ -45,11 +66,14 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-      - test
+      - test-electron-13
       - test-electron-11
+      - test-electron-12
+      - test-electron-14
+      - test-electron-15
       - release:
           requires:
-            - test
+            - test-electron-13
           filters:
             branches:
               only:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+test-results/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/electron/remote"
   },
   "peerDependencies": {
-    "electron": ">= 10.0.0-beta.1"
+    "electron": ">= 13.0.0"
   },
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^2.0.0",
@@ -16,11 +16,11 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.0.12",
+    "@types/node": "^14.17.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
-    "electron": "10.x",
+    "electron": "^13.0.0",
     "mocha": "^7.0.2",
     "mocha-junit-reporter": "^1.23.3",
     "mocha-multi-reporters": "^1.1.7",

--- a/src/internal-ambient.d.ts
+++ b/src/internal-ambient.d.ts
@@ -23,6 +23,6 @@ declare namespace NodeJS {
     electronBinding(name: 'event'): EventBinding;
     electronBinding(name: 'v8_util'): V8UtilBinding;
     electronBinding(name: 'features'): FeaturesBinding;
-    readonly contextId: string;
+    readonly contextId?: string;
   }
 }

--- a/test/all.ts
+++ b/test/all.ts
@@ -52,7 +52,7 @@ function makeRemotely (windowGetter: () => BrowserWindow) {
 function makeWindow () {
   let w: BrowserWindow
   before(async () => {
-    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
+    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false, enableRemoteModule: true } })
     await w.loadURL('about:blank')
     await w.webContents.executeJavaScript(`{
       const chai_1 = window.chai_1 = require('chai')
@@ -68,7 +68,7 @@ function makeWindow () {
 function makeEachWindow () {
   let w: BrowserWindow
   beforeEach(async () => {
-    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
+    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false, enableRemoteModule: true } })
     await w.loadURL('about:blank')
     await w.webContents.executeJavaScript(`{
       const chai_1 = window.chai_1 = require('chai')
@@ -342,6 +342,7 @@ describe('remote module', () => {
         show: false,
         webPreferences: {
           nodeIntegration: true,
+          contextIsolation: false,
           enableRemoteModule: true
         }
       })
@@ -354,7 +355,7 @@ describe('remote module', () => {
       w.loadFile(path.join(fixtures, 'render-view-deleted.html'))
     })
   })
-  
+
   describe('nativeImage serialization', () => {
     const w = makeWindow()
     const remotely = makeRemotely(w)
@@ -431,6 +432,7 @@ describe('remote module', () => {
         show: false,
         webPreferences: {
           nodeIntegration: true,
+          contextIsolation: false,
           enableRemoteModule: true
         }
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,10 +330,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
   integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
-"@types/node@^12.0.12":
-  version "12.12.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
-  integrity sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==
+"@types/node@^14.17.0", "@types/node@^14.6.2":
+  version "14.17.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.18.tgz#0198489a751005f71217744aa966cd1f29447c81"
+  integrity sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1417,13 +1417,13 @@ editor@~1.0.0:
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
   integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
-electron@10.x:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-10.2.0.tgz#4b00f0907b28aca4b93661bb53ce9a4f8ad32201"
-  integrity sha512-GBUyq8dwUqXPkCTkoID+eZ5Pm9GFlLUd2eSoGe8UOaHeW68SgCf5t75/uGHraQ1OIz/0qniyH5M4ebWEHGppyQ==
+electron@^13.0.0:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.4.0.tgz#f9f9e518d8c6bf23bfa8b69580447eea3ca0f880"
+  integrity sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
+    "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
 emoji-regex@^7.0.1:


### PR DESCRIPTION
I have to say it is a bit of a joke a new major version is released which focuses on `electron>=14`, but it is not tested with it.

So I made some changes so that electron 11-15 is tested. To get electron 12/13 working `contextIsolation` needed to be disabled.

Electron 14/15 is not working yet, I am working on that. I am not sure I will succeed, but I will open a separate PR for that.