### PR TITLE
fix: Exclude dist in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "exclude": ["index.d.ts", "main", "renderer"]
+  "exclude": ["dist", "index.d.ts", "main", "renderer"]
 }


### PR DESCRIPTION
To prevent errors like this when running `tsc` twice:

`error TS5055: Cannot write file '/home/anders/electron/remote/dist/src/common/get-electron-binding.d.ts' because it would overwrite input file.`