### PR TITLE
Rename prepublishOnly script to prepare; add {main,renderer}/index.d.ts to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "prepublishOnly": "tsc",
+    "prepare": "tsc",
     "test": "electron test --extension=ts --require=ts-node/register --exit --js-flags=--expose_gc",
     "test:ci": "yarn test --reporter=mocha-multi-reporters --reporter-options=configFile=.circleci/mocha-reporter-config.json"
   },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "files": [
     "README.md",
     "package.json",
-    "main/index.js",
-    "renderer/index.js",
+    "main",
+    "renderer",
     "dist/src",
     "index.d.ts"
   ],


### PR DESCRIPTION
To allow installation directly from GitHub (e.g. `npm i electron/remote#main`).