### PR TITLE
Make catch clauses compatible with TypeScript 4.4

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -467,7 +467,10 @@ export function initialize() {
     try {
       return valueToMeta(event.sender, contextId, func(...args), true)
     } catch (error) {
-      const err = new Error(`Could not call remote function '${func.name || 'anonymous'}'. Check that the function signature is correct. Underlying error: ${error.message}\nUnderlying stack: ${error.stack}\n`);
+      const err = new Error(
+        `Could not call remote function '${func.name || "anonymous"}'. Check that the function signature is correct. Underlying error: ${error}\n` +
+          (error instanceof Error ? `Underlying stack: ${error.stack}\n` : "")
+      );
       (err as any).cause = error
       throw err
     }
@@ -495,7 +498,10 @@ export function initialize() {
     try {
       return valueToMeta(event.sender, contextId, object[method](...args), true)
     } catch (error) {
-      const err = new Error(`Could not call remote method '${method}'. Check that the method signature is correct. Underlying error: ${error.message}\nUnderlying stack: ${error.stack}\n`);
+      const err = new Error(
+        `Could not call remote method '${method}'. Check that the method signature is correct. Underlying error: ${error}` +
+          (error instanceof Error ? `Underlying stack: ${error.stack}\n` : "")
+      );
       (err as any).cause = error
       throw err
     }

--- a/test/all.ts
+++ b/test/all.ts
@@ -1007,7 +1007,7 @@ describe('remote module', () => {
       try {
         throwFunction(new Error('error from main'))
         expect.fail()
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.match(/Could not call remote function/)
         expect(e.cause.message).to.equal('error from main')
       }


### PR DESCRIPTION
In TypeScript 4.4, `--strict` [implies](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables) `--useUnknownInCatchVariables`, so in a `catch (error)` block, `error` has type `unknown` rather than `any`.