### PR TITLE
feat: add isInitialized

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,1 +1,1 @@
-export { initialize, enable } from "./server";
+export { initialize, isInitialized, enable } from "./server";

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -357,10 +357,10 @@ const logStack = function (contents: WebContents, code: string, stack: string | 
   }
 }
 
-let initialized = false;
+let initialized = false
 
 export function isInitialized() {
-  return initialized;
+  return initialized
 }
 
 export function initialize() {

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -357,7 +357,12 @@ const logStack = function (contents: WebContents, code: string, stack: string | 
   }
 }
 
-let initialized = false
+let initialized = false;
+
+export function isInitialized() {
+  return initialized;
+}
+
 export function initialize() {
   if (initialized)
     throw new Error('@electron/remote has already been initialized')


### PR DESCRIPTION
This change adds the "isInitialized" function
Now it is impossible to check whether initialization has been performed. This may cause errors when using modules that also use electron/remote.
Current code (so that it does not throw an error if initialization has already been done):
```js
try { remote.initialize(); } catch { }
```
New code:
```js
if (!remote.isInitialized()) {
     remote.initialize();
}
```