### PR TITLE
fix: add TypeScript interface for SafeStorage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export {
   DownloadItem,
   IncomingMessage,
   MessagePortMain,
+  SafeStorage,
   ServiceWorkers,
   TouchBarButton,
   TouchBarColorPicker,
@@ -47,6 +48,7 @@ export var Notification: typeof Electron.Notification;
 export var powerMonitor: Electron.PowerMonitor;
 export var powerSaveBlocker: Electron.PowerSaveBlocker;
 export var protocol: Electron.Protocol;
+export var safeStorage: Electron.SafeStorage;
 export var screen: Electron.Screen;
 export var session: typeof Electron.session;
 export var ShareMenu: typeof Electron.ShareMenu;


### PR DESCRIPTION
Allows TypeScript to easily access SafeStorage.

e.g 
``` TypeScript
 import { app, safeStorage } from "@electron/remote";
```

afterwards it is accessible by 

``` TypeScript
if (safeStorage.isEncryptionAvailable()) {
    console.log("Encryption is available");
}

```




