### PR TITLE
revert: "Adds TypeScript interface for SafeStorage (#155)"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ export {
   DownloadItem,
   IncomingMessage,
   MessagePortMain,
-  SafeStorage,
   ServiceWorkers,
   TouchBarButton,
   TouchBarColorPicker,
@@ -48,7 +47,6 @@ export var Notification: typeof Electron.Notification;
 export var powerMonitor: Electron.PowerMonitor;
 export var powerSaveBlocker: Electron.PowerSaveBlocker;
 export var protocol: Electron.Protocol;
-export var safeStorage: Electron.SafeStorage;
 export var screen: Electron.Screen;
 export var session: typeof Electron.session;
 export var ShareMenu: typeof Electron.ShareMenu;


### PR DESCRIPTION
This reverts commit 2f79ed6b6cb68e45328e914f643bddb86102622a.

Unfortunately CircleCI tests weren't run on #155 (this has been fixed now) so it wasn't noticed that the change broke tests on older Electron versions where `SafeStorage` isn't implemented. I explored various ways to try to make this conditional if possible, but there's no clean solution that I'm aware of. Let's revert this so that it doesn't break compatibility with older Electron versions.