### PR TITLE
fix: `features.isDesktopCapturerEnabled` error

### DIFF
--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -46,7 +46,7 @@ export const browserModuleNames = [
 
 const features = getElectronBinding('features');
 
-if (!features || !features.isDesktopCapturerEnabled || features.isDesktopCapturerEnabled()) {
+if (features?.isDesktopCapturerEnabled?.() !== false) {
   browserModuleNames.push('desktopCapturer');
 }
 


### PR DESCRIPTION
Refs https://github.com/electron/remote/pull/154

See https://github.com/electron/remote/pull/154#issuecomment-1752156161:

When `features` no longer contains `isDesktopCapturerEnabled`, `!features.isDesktopCapturerEnabled` evaluates to true, which then means the conditional checks the third condition: `features.isDesktopCapturerEnabled()` which throws an error:

```
Uncaught TypeError: features.isDesktopCapturerEnabled is not a function
```