### PR TITLE
build: update yarn.lock to fix audit output

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -335,7 +335,7 @@ crypt@~0.0.1:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
-debug@4.3.4:
+debug@4.3.4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -350,16 +350,9 @@ debug@^2.2.0:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 


### PR DESCRIPTION
We ran `uuaw --audit` and it resulted in a clean yarn audit.

```
Attempting to fix advisory: GHSA-gxpj-cx7g-858c - Regular Expression Denial of Service in debug
Scanning dependency chain:
     electron --> @electron/get --> sumchecker --> debug
[1/9] Trying from: debug@^4.1.0
    Resolving: debug@^4.1.0 --> 4.3.4
[1/9] Updating chain to latest starting at: debug@^4.1.0 results in a patched version: debug@4.3.4
[1/9] Running yarn install now

Attempting to fix advisory: GHSA-gxpj-cx7g-858c - Regular Expression Denial of Service in debug
Scanning dependency chain:
     electron --> @electron/get --> debug
[1/8] Trying from: debug@^4.1.1
    Resolving: debug@^4.1.1 --> 4.3.4
[1/8] Updating chain to latest starting at: debug@^4.1.1 results in a patched version: debug@4.3.4
[1/8] Running yarn install now

Attempting to fix advisory: GHSA-gxpj-cx7g-858c - Regular Expression Denial of Service in debug
Scanning dependency chain:
     mocha-multi-reporters --> debug
[1/2] Trying from: debug@^3.1.0
    Resolving: debug@^3.1.0 --> 3.2.7
[1/2] Updating chain to latest starting at: debug@^3.1.0 results in a patched version: debug@3.2.7
[1/2] Running yarn install now

Audit is clean, looking good cap'n

```