### PR TITLE
fix: optional isViewApiEnabled call

### DIFF
--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -50,6 +50,6 @@ if (features?.isDesktopCapturerEnabled?.() !== false) {
   browserModuleNames.push('desktopCapturer');
 }
 
-if (!features || features.isViewApiEnabled()) {
+if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }


### PR DESCRIPTION
ref https://github.com/electron/remote/commit/168b4677049be317ae3788748544f4cb3d73625d

Same deal but for `isViewApiEnabled`. Should fix `@electron/remote` for Electron 29. Closes #179.