### PR TITLE
ci: revert runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - 31
           - 32
           - 33
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
`ubuntu-latest` is now Ubuntu 24.04 and CI is now failing due to the sandboxing changes with running Electron. To unblock CI here for now, revert to Ubuntu 22.04 until a proper solution can be implemented.