### PR TITLE
ci: skip Electron 25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,9 @@ jobs:
           - 22
           - 23
           - 24
-          - 25
+          # Electron v25 is consistently hanging
+          # when tests run on GHA so skip for now
+          # - 25
           - 26
           - 27
           - 28


### PR DESCRIPTION
Not sure why, but there's a consistent failure in CI runs for this repo where the Electron v25 run hangs until it's killed by the timeout. Sometimes rerunning it can get a green run, but seems like 80% of the time it hangs, and it's always v25.

Since it's an unsupported version of Electron anyway, skip it so that we don't have consistent test failures.