### PR TITLE
ci: update Electron versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         electron-version:
           - 12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
           - 31
           - 32
           - 33
+          - 34
+          - 35
+          - 36
+          - 37
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -54,7 +54,5 @@ if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }
 
-try {
-  (process as any)._linkedBinding('electron_browser_service_worker_main');
-  browserModuleNames.push('ServiceWorkerMain');
-} catch {}
+(process as any)._linkedBinding('electron_browser_service_worker_main');
+browserModuleNames.push('ServiceWorkerMain');

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -54,6 +54,6 @@ if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }
 
-if (Object.keys(require('electron')).includes('ServiceWorkerMain')) {
+if (true || Object.keys(require('electron')).includes('ServiceWorkerMain')) {
   browserModuleNames.push('ServiceWorkerMain');
 }

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -6,6 +6,8 @@ export const commonModuleNames = [
   'shell',
 ];
 
+const mainModules = Object.keys(require('electron'))
+
 export const browserModuleNames = [
   'app',
   'autoUpdater',
@@ -53,3 +55,8 @@ if (features?.isDesktopCapturerEnabled?.() !== false) {
 if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }
+
+try {
+  getElectronBinding('electron_browser_service_worker_main');
+  browserModuleNames.push('ServiceWorkerMain');
+} catch {}

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -54,6 +54,6 @@ if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }
 
-if ('ServiceWorkerMain' in Object.keys(require('electron'))) {
+if (Object.keys(require('electron')).includes('ServiceWorkerMain')) {
   browserModuleNames.push('ServiceWorkerMain');
 }

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -6,8 +6,6 @@ export const commonModuleNames = [
   'shell',
 ];
 
-const mainModules = Object.keys(require('electron'))
-
 export const browserModuleNames = [
   'app',
   'autoUpdater',
@@ -57,6 +55,6 @@ if (features?.isViewApiEnabled?.() !== false) {
 }
 
 try {
-  getElectronBinding('electron_browser_service_worker_main');
+  (process as any)._linkedBinding('electron_browser_service_worker_main');
   browserModuleNames.push('ServiceWorkerMain');
 } catch {}

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -54,5 +54,6 @@ if (features?.isViewApiEnabled?.() !== false) {
   browserModuleNames.push('ImageView');
 }
 
-(process as any)._linkedBinding('electron_browser_service_worker_main');
-browserModuleNames.push('ServiceWorkerMain');
+if ('ServiceWorkerMain' in Object.keys(require('electron'))) {
+  browserModuleNames.push('ServiceWorkerMain');
+}


### PR DESCRIPTION
This has gotten stale so catch up to the just released E37. Also turns off `fail-fast` since this is a large matrix and we don't want a flake to cancel all jobs.