### PR TITLE
fix: add ServiceWorkerMain module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         electron-version:
           - 12
@@ -41,6 +42,10 @@ jobs:
           - 31
           - 32
           - 33
+          - 34
+          - 35
+          - 36
+          - 37
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/src/common/module-names.ts
+++ b/src/common/module-names.ts
@@ -32,6 +32,7 @@ export const browserModuleNames = [
   'safeStorage',
   'screen',
   'session',
+  'ServiceWorkerMain',
   'ShareMenu',
   'systemPreferences',
   'TopLevelWindow',


### PR DESCRIPTION
This was added in E35. Expands the test matrix Electron versions and also disables `fail-fast` so the full matrix is run even if there are failures.