### PR TITLE
ci: add E43 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           - 40
           - 41
           - 42
+          - 43
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Per [the `43-x-y` board](https://github.com/orgs/electron/projects/129/views/3?pane=issue&itemId=184431826).